### PR TITLE
Drop support for Django < 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ cache: pip
 
 env:
   matrix:
-    - DJANGO='>= 1.8, < 1.9'
-    - DJANGO='>= 1.9, < 1.10'
     - DJANGO='>= 1.10, < 1.11'
     - DJANGO='>= 1.11, < 1.12'
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,6 @@ setup(
 
         # Supported versions of Django
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
 
@@ -48,5 +46,5 @@ setup(
     # Dependencies
     install_requires=[
         'Django >= 1.8, < 1.12',
-        'djangorestframework >= 3.0, < 4.0',
+        'djangorestframework >= 3.0, < 3.7',
     ])


### PR DESCRIPTION
Fixes #12 

Since we depend on Django Rest Framework and they only support Django >= 1.10, we are dropping support for previous versions.