### PR TITLE
Add generic view for saving a serializer.

### DIFF
--- a/rest_email_auth/generics.py
+++ b/rest_email_auth/generics.py
@@ -1,0 +1,35 @@
+"""
+A collection of reusable views.
+"""
+
+from rest_framework import generics, status
+from rest_framework.response import Response
+
+
+class SerializerSaveView(generics.GenericAPIView):
+    """
+    Generic view for saving a serializer and returning the results.
+    """
+
+    def post(self, request):
+        """
+        Save the provided data using the class' serializer.
+
+        Args:
+            request:
+                The request being made.
+
+        Returns:
+            An ``APIResponse`` instance. If the request was successful
+            the response will have a 200 status code and contain the
+            serializer's data. Otherwise a 400 status code and the
+            request's errors will be returned.
+        """
+        serializer = self.get_serializer(data=request.data)
+
+        if serializer.is_valid():
+            serializer.save()
+
+            return Response(serializer.data)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/rest_email_auth/tests/generics/test_serializer_save_view.py
+++ b/rest_email_auth/tests/generics/test_serializer_save_view.py
@@ -1,0 +1,59 @@
+from rest_framework import serializers, status
+
+from rest_email_auth import generics
+
+
+class ExampleSerializer(serializers.Serializer):
+    """
+    Serializer for testing views.
+    """
+    foo = serializers.CharField()
+
+    def save(self):
+        """
+        Mock save method.
+        """
+        pass
+
+
+class ExampleView(generics.SerializerSaveView):
+    """
+    View that extends from the generic view we're testing.
+    """
+    serializer_class = ExampleSerializer
+
+
+def test_post_invalid(api_rf):
+    """
+    Sending an invalid POST request to the view should return the
+    serializer's errors.
+    """
+    request = api_rf.post('/', {})
+    response = ExampleView.as_view()(request)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    serializer = ExampleSerializer(data={})
+    assert not serializer.is_valid()
+
+    assert response.data == serializer.errors
+
+
+def test_post_valid(api_rf):
+    """
+    Sending a valid POST request to the view should call the
+    serializer's ``save`` method and return the serializer's data.
+    """
+    data = {
+        'foo': 'bar',
+    }
+
+    request = api_rf.post('/', data)
+    response = ExampleView.as_view()(request)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    serializer = ExampleSerializer(data=data)
+    assert serializer.is_valid()
+
+    assert response.data == serializer.data

--- a/rest_email_auth/views.py
+++ b/rest_email_auth/views.py
@@ -1,38 +1,17 @@
 """Views for the ``rest_email_auth`` app.
 """
 
-from rest_framework import generics, status
+from rest_framework import generics
 
 from rest_email_auth import serializers
+from rest_email_auth.generics import SerializerSaveView
 
 
-class EmailVerificationView(generics.CreateAPIView):
+class EmailVerificationView(SerializerSaveView):
     """
     Verify a user's email address.
     """
     serializer_class = serializers.EmailVerificationSerializer
-
-    def create(self, request, *args, **kwargs):
-        """
-        Override the create method to return a 200 response.
-
-        Args:
-            request:
-                The request being made.
-            args:
-                The arguments to pass to the parent create method.
-            kwargs:
-                The keyword arguments to pass to the parent create
-                method.
-
-        Returns:
-            A response with a 200 status code.
-        """
-        response = super(EmailVerificationView, self).create(
-            request, *args, **kwargs)
-        response.status_code = status.HTTP_200_OK
-
-        return response
 
 
 class RegistrationView(generics.CreateAPIView):


### PR DESCRIPTION
The generic view uses POST data to construct and save a serializer.