### PR TITLE
Allow for resending of verification emails

### DIFF
--- a/rest_email_auth/serializers.py
+++ b/rest_email_auth/serializers.py
@@ -4,12 +4,17 @@ The serializers handle the conversion of data between the JSON or form
 data the API receives and native Python datatypes.
 """
 
+import logging
+
 from django.contrib.auth import get_user_model, password_validation
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
 
 from rest_email_auth import models
+
+
+logger = logging.getLogger(__name__)
 
 
 UserModel = get_user_model()
@@ -163,3 +168,32 @@ class RegistrationSerializer(serializers.ModelSerializer):
         password_validation.validate_password(password)
 
         return password
+
+
+class ResendVerificationSerializer(serializers.Serializer):
+    """
+    Serializer for resending a verification email.
+    """
+    email = serializers.EmailField()
+
+    def save(self):
+        """
+        Resend a verification email to the provided address.
+
+        If the provided email is already verified no action is taken.
+        """
+        try:
+            email = models.EmailAddress.objects.get(
+                email=self.validated_data['email'],
+                is_verified=False)
+
+            logger.debug(
+                'Resending verification email to %s',
+                self.validated_data['email'])
+
+            email.send_confirmation()
+        except models.EmailAddress.DoesNotExist:
+            logger.debug(
+                'Not resending verification email to %s because the address '
+                "doesn't exist in the database.",
+                self.validated_data['email'])

--- a/rest_email_auth/tests/conftest.py
+++ b/rest_email_auth/tests/conftest.py
@@ -3,9 +3,20 @@
 
 import pytest
 
-from rest_framework.test import APIRequestFactory
+from rest_framework.test import APIClient, APIRequestFactory
 
 from rest_email_auth import factories
+
+
+@pytest.fixture
+def api_client():
+    """
+    Fixture to get a client for making API requests.
+
+    Returns:
+        An instance of the APIClient provided by DRF.
+    """
+    return APIClient()
 
 
 @pytest.fixture

--- a/rest_email_auth/tests/serializers/test_resend_verification_serializer.py
+++ b/rest_email_auth/tests/serializers/test_resend_verification_serializer.py
@@ -1,0 +1,69 @@
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from rest_email_auth import serializers
+
+
+@mock.patch(
+    'rest_email_auth.serializers.models.EmailAddress.send_confirmation',
+    autospec=True)
+def test_save(mock_send_confirmation, email_factory):
+    """
+    Saving the serializer should send a new confirmation.
+    """
+    email = email_factory()
+
+    data = {
+        'email': email.email,
+    }
+
+    serializer = serializers.ResendVerificationSerializer(data=data)
+    assert serializer.is_valid()
+
+    serializer.save()
+
+    assert mock_send_confirmation.call_count == 1
+
+
+@mock.patch(
+    'rest_email_auth.serializers.models.EmailAddress.send_confirmation',
+    autospec=True)
+def test_save_nonexistent_email(mock_send_confirmation, db):
+    """
+    If the provided email address is not in the database, no action
+    should be taken.
+    """
+    data = {
+        'email': 'test@example.com',
+    }
+
+    serializer = serializers.ResendVerificationSerializer(data=data)
+    assert serializer.is_valid()
+
+    serializer.save()
+
+    assert mock_send_confirmation.call_count == 0
+
+
+@mock.patch(
+    'rest_email_auth.serializers.models.EmailAddress.send_confirmation',
+    autospec=True)
+def test_save_verified_email(mock_send_confirmation, email_factory):
+    """
+    If the provided email has already been verified, no action should be
+    taken.
+    """
+    email = email_factory(is_verified=True)
+
+    data = {
+        'email': email.email,
+    }
+
+    serializer = serializers.ResendVerificationSerializer(data=data)
+    assert serializer.is_valid()
+
+    serializer.save()
+
+    assert mock_send_confirmation.call_count == 0

--- a/rest_email_auth/tests/views/test_resend_verification_view.py
+++ b/rest_email_auth/tests/views/test_resend_verification_view.py
@@ -1,0 +1,28 @@
+import pytest
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from rest_email_auth import serializers
+
+
+url = reverse('rest-email-auth:resend-verification')
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_post_resend_verification(api_client):
+    """
+    Sending a POST request to the endpoint should send a confirmation
+    email to the provided address.
+    """
+    data = {'email': 'test@example.com'}
+
+    response = api_client.post(url, data)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    serializer = serializers.ResendVerificationSerializer(data=data)
+    assert serializer.is_valid()
+
+    assert response.data == serializer.data

--- a/rest_email_auth/urls.py
+++ b/rest_email_auth/urls.py
@@ -7,7 +7,22 @@ from django.conf.urls import url
 from rest_email_auth import views
 
 
+app_name = 'rest-email-auth'
+
+
 urlpatterns = [
-    url(r'^register/$', views.RegistrationView.as_view(), name='register'),
-    url(r'^verify-email/$', views.EmailVerificationView.as_view(), name='verify-email'),    # noqa
+    url(
+        r'^register/$',
+        views.RegistrationView.as_view(),
+        name='register'),
+
+    url(
+        r'^resend-verification/$',
+        views.ResendVerificationView.as_view(),
+        name='resend-verification'),
+
+    url(
+        r'^verify-email/$',
+        views.EmailVerificationView.as_view(),
+        name='verify-email'),
 ]

--- a/rest_email_auth/views.py
+++ b/rest_email_auth/views.py
@@ -19,3 +19,10 @@ class RegistrationView(generics.CreateAPIView):
     Register a new user.
     """
     serializer_class = serializers.RegistrationSerializer
+
+
+class ResendVerificationView(SerializerSaveView):
+    """
+    Resend an email verification to a specific address.
+    """
+    serializer_class = serializers.ResendVerificationSerializer

--- a/test_settings.py
+++ b/test_settings.py
@@ -23,3 +23,6 @@ TEMPLATES = [
         },
     },
 ]
+
+
+ROOT_URLCONF = 'test_urls'

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import include, url
+
+
+urlpatterns = [
+    url(r'^', include('rest_email_auth.urls')),
+]


### PR DESCRIPTION
Closes #6 

This PR adds an endpoint for resending a verification email to a specific address.

##### TODO

- [x] Add serializer for resending verification emails
- [x] Add view/endpoint that utilizes the serializer