### PR TITLE
Limit support to Django's supported versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: python
 python:
   - 2.7
@@ -8,9 +9,14 @@ python:
 cache: pip
 
 env:
-  matrix:
-    - DJANGO='>= 1.10, < 1.11'
-    - DJANGO='>= 1.11, < 1.12'
+  - DJANGO='>= 1.11, < 1.12'
+  - DJANGO='>= 2.0, < 2.1'
+
+matrix:
+  exclude:
+    # Django dropped support for Python 2 in versions 2.0 and above
+    - python: 2.7
+      env: DJANGO='>= 2.0, < 2.1'
 
 install:
   - pip install --upgrade pip

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Requirements
 ============
 
   * Python 2.7, 3.4, 3.5, or 3.6
-  * Django 1.10 or above
+  * Django 1.11 or 2.0. Other versions may work, but they are not officially supported.
 
 
 Getting the Package

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
 
         # Supported versions of Django
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
 


### PR DESCRIPTION
As of now, Django supports 1.8, 1.11, and 2.0. Django Rest Framework does not support 1.8, so we only support versions 1.11 and 2.0.