### PR TITLE
Fix documentation.

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,6 +8,7 @@ In Development
 Bugfixes
   * :issue:`42`: Fix issue with creating multiple primary emails.
   * :issue:`45`: Confirmation tokens are now deleted once they have been used.
+  * :issue:`46`: Documentation for endpoints using the generic ``SerializerSaveView`` is no longer broken.
 
 Miscellaneous
   * :issue:`41`: Fix useless test.

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from rest_framework.documentation import include_docs_urls
+
 
 urlpatterns = [
     url(r'^account/', include('rest_email_auth.urls')),
     url(r'^admin/', admin.site.urls),
+    url(r'^docs/', include_docs_urls(title='Example Project')),
 ]

--- a/example_project/requirements.txt
+++ b/example_project/requirements.txt
@@ -1,2 +1,3 @@
 Django == 1.11.4
+coreapi == 2.3.3
 django-rest-email-auth == 0.4.3

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,1 +1,3 @@
 codecov == 2.0.15
+# coreapi is required for the example project's tests to pass
+coreapi == 2.3.3

--- a/rest_email_auth/generics.py
+++ b/rest_email_auth/generics.py
@@ -33,3 +33,7 @@ class SerializerSaveView(generics.GenericAPIView):
             return Response(serializer.data)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    # We reset the docstring because it's used to generate DRF's docs,
+    # and documentation on the 'post' method has a higher specificity
+    # than a class-level docstring.
+    post.__doc__ = ''


### PR DESCRIPTION
For views that extend from `SerializerSaveView`, the autogenerated
documentation is no longer broken.

Fixes #46 