### PR TITLE
Add post-registration signal.

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 In Development
 --------------
 
+Features
+  * :issue:`47`: Send a signal out when a user registers.
+
 Bugfixes
   * :issue:`42`: Fix issue with creating multiple primary emails.
   * :issue:`45`: Confirmation tokens are now deleted once they have been used.

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -1,0 +1,26 @@
+==============
+Advanced Usage
+==============
+
+
+Signals
+=======
+
+`Signals <django-signals_>`_ allow other applications to hook into rest-email-auth and add custom behaviors for events from the app.
+
+The signals referenced below are importable from ``rest_email_auth.signals``.
+
+
+Registration
+------------
+
+**Signal Name:** ``user_registered``
+
+This signal is triggered after a user has successfully registered. It will not be triggered if a user attempts to register with a duplicate email address.
+
+.. note::
+
+    This signal fires before the user has verified their email address.
+
+
+.. _django-signals: https://docs.djangoproject.com/en/dev/topics/signals/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@
    endpoints
    commands
    custom-serializers
+   advanced-usage
    CHANGELOG
 
 

--- a/rest_email_auth/serializers.py
+++ b/rest_email_auth/serializers.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
 
-from rest_email_auth import models
+from rest_email_auth import models, signals
 
 
 logger = logging.getLogger(__name__)
@@ -348,6 +348,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
                 email=email,
                 user=user)
             email_instance.send_confirmation()
+
+            signals.user_registered.send(sender=self.__class__, user=user)
 
         return user
 

--- a/rest_email_auth/signals.py
+++ b/rest_email_auth/signals.py
@@ -1,0 +1,11 @@
+"""
+Custom signals used by django-rest-email-auth.
+
+These signals allow other applications to easily add custom behavior to
+processes from this module.
+"""
+
+from django import dispatch
+
+
+user_registered = dispatch.Signal(providing_args=['user'])

--- a/rest_email_auth/tests/conftest.py
+++ b/rest_email_auth/tests/conftest.py
@@ -4,11 +4,19 @@
 import copy
 import logging
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import pytest
 
 from rest_framework.test import APIClient, APIRequestFactory
 
-from rest_email_auth import app_settings as application_settings, factories
+from rest_email_auth import (
+    app_settings as application_settings,
+    factories,
+    signals)
 
 
 logger = logging.getLogger(__name__)
@@ -125,6 +133,19 @@ def password_reset_token_factory(db):
         The factory used to create ``PasswordResetToken`` instances.
     """
     return factories.PasswordResetTokenFactory
+
+
+@pytest.fixture
+def registration_listener():
+    """
+    Fixture to get a listener for the 'user_registered' signal.
+    """
+    listener = mock.Mock(name='Mock Registration Listener')
+    signals.user_registered.connect(listener)
+
+    yield listener
+
+    signals.user_registered.disconnect(listener)
 
 
 @pytest.fixture

--- a/rest_email_auth/tests/serializers/test_registration_serializer.py
+++ b/rest_email_auth/tests/serializers/test_registration_serializer.py
@@ -11,7 +11,7 @@ from rest_email_auth import serializers
 
 
 @pytest.mark.django_db
-def test_create_new_user():
+def test_create_new_user(registration_listener):
     """
     Saving a serializer with valid data should create a new user.
     """
@@ -40,8 +40,11 @@ def test_create_new_user():
     # Make sure we sent out an email confirmation
     assert mock_send_confirmation.call_count == 1
 
+    # Make sure we sent a registration event
+    assert registration_listener.call_count == 1
 
-def test_register_duplicate_email(email_factory):
+
+def test_register_duplicate_email(email_factory, registration_listener):
     """
     Attempting to register with an email that has already been verified
     should send an email to the owner of the email address notifying
@@ -65,6 +68,9 @@ def test_register_duplicate_email(email_factory):
 
     assert get_user_model().objects.count() == 1
     assert mock_send_duplicate_signup.call_count == 1
+
+    # We should not get a registration event for a duplicate email
+    assert registration_listener.call_count == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #47 

This PR adds a signal that is sent once a user has successfully registered.