### PR TITLE
Add signal indicating email address was verified.

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+v1.1.0
+------
+
+Features
+  * :issue:`53`: Emit a signal when an email address is verified.
+
+
 v1.0.0
 ------
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -11,10 +11,27 @@ Signals
 The signals referenced below are importable from ``rest_email_auth.signals``.
 
 
+Email Verification
+------------------
+
+**Signal Name:** ``email_verified``
+
+**Signal Arguments:**
+
+* **email:** The ``EmailAddress`` instance that was verfied.
+
+This signal is triggered after an email address is verifed using an ``EmailConfirmation`` instance. Unless you have added custom logic allowing email addresses to be unverified, you can assume that the instance will be marked as verified after this point.
+
+
 Registration
 ------------
 
 **Signal Name:** ``user_registered``
+
+**Signal Arguments:**
+
+* **user:**
+  The ``settings.AUTH_USER_MODEL`` instance that just registered.
 
 This signal is triggered after a user has successfully registered. It will not be triggered if a user attempts to register with a duplicate email address.
 

--- a/rest_email_auth/models.py
+++ b/rest_email_auth/models.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext_lazy as _
 
-from rest_email_auth import app_settings, managers
+from rest_email_auth import app_settings, managers, signals
 
 
 logger = logging.getLogger(__name__)
@@ -147,6 +147,8 @@ class EmailConfirmation(models.Model):
         """
         self.email.is_verified = True
         self.email.save()
+
+        signals.email_verified.send(email=self.email, sender=self.__class__)
 
         logger.info('Verified email address: %s', self.email.email)
 

--- a/rest_email_auth/signals.py
+++ b/rest_email_auth/signals.py
@@ -8,4 +8,6 @@ processes from this module.
 from django import dispatch
 
 
+email_verified = dispatch.Signal(providing_args=['email'])
+
 user_registered = dispatch.Signal(providing_args=['user'])

--- a/rest_email_auth/tests/conftest.py
+++ b/rest_email_auth/tests/conftest.py
@@ -125,6 +125,19 @@ def email_factory(db):
 
 
 @pytest.fixture
+def email_verification_listener():
+    """
+    Fixture to get a listener for the 'email_verified' signal.
+    """
+    listener = mock.Mock(name='Mock Email Verification Listener')
+    signals.email_verified.connect(listener)
+
+    yield listener
+
+    signals.email_verified.disconnect(listener)
+
+
+@pytest.fixture
 def password_reset_token_factory(db):
     """
     Fixture to get the factory usedd to create password reset tokens.

--- a/rest_email_auth/tests/models/test_email_confirmation_model.py
+++ b/rest_email_auth/tests/models/test_email_confirmation_model.py
@@ -10,7 +10,10 @@ from django.template.loader import render_to_string
 from rest_email_auth import models
 
 
-def test_confirm(email_confirmation_factory, email_factory):
+def test_confirm(
+        email_confirmation_factory,
+        email_factory,
+        email_verification_listener):
     """
     Confirming a confirmation should mark the associated email address
     as verified.
@@ -22,6 +25,10 @@ def test_confirm(email_confirmation_factory, email_factory):
     email.refresh_from_db()
 
     assert email.is_verified
+    assert email_verification_listener.call_count == 1
+    assert email_verification_listener.call_args[1]['sender'] == \
+        confirmation.__class__
+    assert email_verification_listener.call_args[1]['email'] == email
 
 
 def test_create_email_confirmation(email_factory):


### PR DESCRIPTION
The signal is emitted when an EmailConfirmation instance is used to
confirm an email address.

Closes #53