### PR TITLE
Use django-email-utils to send emails.

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+In Development
+--------------
+
+Features:
+  * Use ``django-email-utils`` for email sending. This allows us to easily send both HTML and plain text templated emails.
+
+
 v1.1.0
 ------
 

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
     # Dependencies
     install_requires=[
         'Django >= 1.10',
+        'django-email-utils',
         'djangorestframework >= 3.0',
     ])


### PR DESCRIPTION
This allows us to support sending both plain text and HTML emails.