### PR TITLE
Drop support for python < 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
 ---
+dist: xenial
 language: python
 python:
-  - 2.7
-  - 3.4
-  - 3.5
   - 3.6
+  - 3.7
 
 cache: pip
 
 env:
   - DJANGO='>= 1.11, < 1.12'
   - DJANGO='>= 2.0, < 2.1'
-
-matrix:
-  exclude:
-    # Django dropped support for Python 2 in versions 2.0 and above
-    - python: 2.7
-      env: DJANGO='>= 2.0, < 2.1'
+  - DJANGO='>= 2.1, < 2.2'
 
 install:
   - pip install --upgrade pip
@@ -38,8 +32,8 @@ jobs:
     - stage: PyPI release
       if: tag IS present
 
-      python: 3.6
-      env: DJANGO='>= 1.11, < 1.12'
+      python: "3.6"
+      env: DJANGO='>= 2.1, < 2.2'
 
       # Skip usual steps
       install: skip

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+v2.0.0
+------
+
+Breaking Changes
+  * Dropped support for Python versions less than 3.6 and added support for Python 3.7.
+
+
 v1.2.0
 ------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,8 +6,8 @@ Installation
 Requirements
 ============
 
-  * Python 2.7, 3.4, 3.5, or 3.6
-  * Django 1.11 or 2.0. Other versions may work, but they are not officially supported.
+  * Python 3.6 or 3.7
+  * Django 1.11, 2.0, or 2.1. Other versions may work, but they are not officially supported.
 
 
 Getting the Package

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
-sphinx == 1.6.7
-sphinxcontrib-httpdomain == 1.6.0
+sphinx == 1.8.3
+sphinxcontrib-httpdomain == 1.7.0
 sphinx-autobuild == 0.7.1
-sphinx-issues == 0.4.0
-sphinx_rtd_theme == 0.2.4
+sphinx-issues == 1.2.0
+sphinx_rtd_theme == 0.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
-factory_boy == 2.10.0
-flake8 == 3.5.0
-mock == 2.0.0 ; python_version < '3.3'
-pytest == 3.4.0
-pytest-django == 3.1.2
+factory_boy == 2.11.1
+flake8 == 3.7.1
+mock == 2.0.0; python_version < '3.3'
+pytest == 4.1.1
+pytest-django == 3.4.5

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
 
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
@@ -32,12 +33,9 @@ setup(
 
         # Supported versions of Python
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # Include the actual source code


### PR DESCRIPTION
Python 2.7 is EOL in less than a year and Python 3 versions below 3.6 are no longer supported. Similarly, we now support Python 3.7.