### PR TITLE
Add setting for email verification passwords

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,6 +8,9 @@ v2.0.0
 Breaking Changes
   * Dropped support for Python versions less than 3.6 and added support for Python 3.7.
 
+Features
+  * :issue:`59`: Add setting to determine if users must provide their password when verifying an email address. To maintain backwards compatibility, the setting defaults to ``True``.
+
 Miscellaneous
   * :issue:`61`: Format code with ``black``.
 
@@ -15,7 +18,7 @@ Miscellaneous
 v1.2.0
 ------
 
-Features:
+Features
   * Use ``django-email-utils`` for email sending. This allows us to easily send both HTML and plain text templated emails.
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,6 +49,20 @@ The duration of the grace period after a confirmation expires before it will be
 deleted by the ``cleanemailconfirmations`` command. See :ref:`clean-email-confirmations` for more information.
 
 
+.. _email-verification-password-required:
+
+``EMAIL_VERIFICATION_PASSWORD_REQUIRED``
+----------------------------------------
+
+Default: ``True``
+
+A boolean indicating if users must provide their password when verifying an email address. Enabling this setting provides slightly more security at the cost of a decreased user experience.
+
+.. note::
+
+    This setting was added in v2.0.0. To maintain backwards compatibility, it is enabled by default.
+
+
 .. _config-registration-serializer:
 
 ``REGISTRATION_SERIALIZER``

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -51,7 +51,7 @@ email address.
 .. http:post:: /verify-email/
 
     :<json string key: The verification key the user received.
-    :<json string password: The user's password.
+    :<json string password: The user's password. This field is only required if :ref:`email-verification-password-required` is set to ``True``.
 
     :>json string email: The email address that was verified.
 

--- a/rest_email_auth/app_settings.py
+++ b/rest_email_auth/app_settings.py
@@ -68,6 +68,14 @@ class AppSettings(object):
         )
 
     @property
+    def EMAIL_VERIFICATION_PASSWORD_REQUIRED(self):
+        """
+        A boolean indicating if the user's password is required to
+        verify their email address.
+        """
+        return self._setting("EMAIL_VERIFICATION_PASSWORD_REQUIRED", True)
+
+    @property
     def EMAIL_VERIFICATION_URL(self):
         """
         The template to use for the email verification url.


### PR DESCRIPTION
Added a setting to select whether or not the user's password is required when verifying an email address.

Closes #59.