### PR TITLE
Support for Django 3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.9"
 
       - name: Build package
         run: python setup.py sdist bdist_wheel

--- a/.github/workflows/review-build.yml
+++ b/.github/workflows/review-build.yml
@@ -18,12 +18,14 @@ jobs:
     strategy:
       matrix:
         django-version:
-          - '>= 1.11, < 1.12'
-          - '>= 2.0, < 2.1'
-          - '>= 2.1, < 2.2'
+          - '>= 2.2, < 2.3'
+          - '>= 3.0, < 3.1'
+          - '>= 3.1, < 3.2'
         python-version:
           - "3.6"
           - "3.7"
+          - "3.8"
+          - "3.9"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ django-rest-email-auth
 ######################
 
 .. image:: https://img.shields.io/github/workflow/status/cdriehuys/django-rest-email-auth/Review%20Build/master
-    :target: https://travis-ci.org/cdriehuys/django-rest-email-auth
+    :target: https://github.com/cdriehuys/django-rest-email-auth/actions?query=workflow%3A%22Review+Build%22+branch%3Amaster
 
 .. image:: https://img.shields.io/codecov/c/github/cdriehuys/django-rest-email-auth.svg
     :target: https://codecov.io/gh/cdriehuys/django-rest-email-auth
@@ -32,6 +32,14 @@ Features:
   * Authentication using any of a user's verified email addresses
   * Registration of new users
   * Password resets using verified emails
+
+*************
+Compatibility
+*************
+
+| **Python:** 3.6 or later
+| **Django:** Versions 2.2 through 3.1
+| **Django REST Framework:** 3.10 or later
 
 ***************
 Adding Features

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+In Development
+--------------
+
+Breaking Changes
+  * Dropped support for Django versions before 2.2.
+  * Dropped support for Django Rest Framework versions before 3.10.
+
+Features
+  * :issue:`82`: Added support for Django versions up to 3.1.
+
 
 v2.1.0
 ------
@@ -13,7 +23,7 @@ v2.0.3
 ------
 
 Bugfixes
-* :issue:`77`: Fix dependency issues for older versions of Django.
+  * :issue:`77`: Fix dependency issues for older versions of Django.
 
 
 v2.0.2

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,3 +1,5 @@
+.. _configuration-page:
+
 =============
 Configuration
 =============

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,8 +6,9 @@ Installation
 Requirements
 ============
 
-  * Python 3.6 or 3.7
-  * Django 1.11, 2.0, or 2.1. Other versions may work, but they are not officially supported.
+* Python >= 3.6
+* Django >= 2.2 and <= 3.1. Other versions may work, but they are not
+  officially supported.
 
 
 Getting the Package
@@ -54,17 +55,21 @@ In :file:`settings.py`, make sure the following settings are present::
         'PASSWORD_RESET_URL': 'https://example.com/reset/{key}',
     }
 
+See :ref:`configuration-page` for a full list of settings.
 
 Email Setup
 -----------
 
-In addition to the above settings, we also require that Django be configured to send emails. Please configure any of the ``EMAIL_*`` settings that apply to your setup. See Django's `email settings`_ for more information.
+In addition to the above settings, we also require that Django be configured to
+send emails. Please configure any of the ``EMAIL_*`` settings that apply to your
+setup. See Django's `email settings`_ for more information.
 
 
 URLs
 ----
 
-After the settings have been configured, include the app's URLs in :file:`urls.py`::
+After the settings have been configured, include the app's URLs in
+:file:`urls.py`::
 
     from django.urls import include, path
     # If you're using Django 1.11:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,3 +1,3 @@
-codecov == 2.0.15
 # coreapi is required for the example project's tests to pass
 coreapi == 2.3.3
+coverage == 5.4

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
-sphinx == 1.8.3
+sphinx == 3.4.3
 sphinxcontrib-httpdomain == 1.7.0
-sphinx-autobuild == 0.7.1
+sphinx-autobuild == 2020.9.1
 sphinx-issues == 1.2.0
-sphinx_rtd_theme == 0.4.2
+sphinx_rtd_theme == 0.5.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,5 @@
 black == 20.8b1
 factory_boy == 3.2.0
 flake8 == 3.8.4
-mock == 4.0.3; python_version < '3.3'
 pytest == 6.2.2
-pytest-django == 3.10.0
+pytest-django == 4.1.0

--- a/rest_email_auth/tests/management/commands/test_cleanemailconfirmations_command.py
+++ b/rest_email_auth/tests/management/commands/test_cleanemailconfirmations_command.py
@@ -1,7 +1,7 @@
 import datetime
+from io import StringIO
 
 from django.core import management
-from django.utils.six import StringIO
 
 import pytest
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description="Django app for email based authentication and registration.",
     long_description=get_description(),
     author="Chathan Driehuys",
-    author_email="cdriehuys@gmail.com",
+    author_email="chathan@driehuys.com",
     url="https://github.com/cdriehuys/django-rest-email-auth",
     license="MIT",
     # Additional classifiers for PyPI
@@ -21,9 +21,9 @@ setup(
         "Development Status :: 5 - Production/Stable",
         # Supported versions of Django
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
@@ -38,8 +38,9 @@ setup(
     packages=find_packages(),
     # Dependencies
     install_requires=[
-        "Django >= 1.10",
-        "django-email-utils < 1.0",
-        "djangorestframework >= 3.0, < 3.12",
+        "Django >= 2.2, < 3.2",
+        "django-email-utils >= 1.0, < 2.0",
+        # DRF 3.10 is the first to support our minimum Django version of 2.2.
+        "djangorestframework >= 3.10",
     ],
 )


### PR DESCRIPTION
Drop support for Django < 2.2 and DRF < 3.10.

Closes #82

