### PR TITLE
docs: Update Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+
+  tools:
+    python: "3.11"
+
+  jobs:
+    post_create_environment:
+      - pip install poetry
+      - poetry config virtualenvs.create false
+
+    post_install:
+      - poetry install --with docs
+
+sphinx:
+  configuration: docs/conf.py

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_parser", "sphinxcontrib.httpdomain", "sphinx_issues"]
+extensions = ["myst_parser", "sphinxcontrib.httpdomain"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -59,10 +59,6 @@ pygments_style = "sphinx"
 # If true, `todo` and `todoList` produce output, else they produce
 # nothing.
 todo_include_todos = False
-
-
-# Configuration for 'sphinx-issues'
-issues_github_path = "cdriehuys/django-rest-email-auth"
 
 
 # -- Options for HTML output -------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -924,26 +924,6 @@ sphinx = "*"
 test = ["pytest", "pytest-cov"]
 
 [[package]]
-name = "sphinx-issues"
-version = "1.2.0"
-description = "A Sphinx extension for linking to your project's issue tracker"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "sphinx-issues-1.2.0.tar.gz", hash = "sha256:845294736c7ac4c09c706f13431f709e1164037cbb00f6bf623ae16eccf509f3"},
-    {file = "sphinx_issues-1.2.0-py2.py3-none-any.whl", hash = "sha256:1208e1869742b7800a45b3c47ab987b87b2ad2024cbc36e0106e8bba3549dd22"},
-]
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["flake8 (==3.6.0)", "flake8-bugbear (==18.8.0)", "mock", "pre-commit (==1.13.0)", "pytest", "tox"]
-lint = ["flake8 (==3.6.0)", "flake8-bugbear (==18.8.0)", "pre-commit (==1.13.0)"]
-tests = ["mock", "pytest"]
-
-[[package]]
 name = "sphinx-rtd-theme"
 version = "1.2.0"
 description = "Read the Docs theme for Sphinx"
@@ -1010,6 +990,22 @@ files = [
 [package.extras]
 lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["html5lib", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-httpdomain"
+version = "1.8.1"
+description = "Sphinx domain for documenting HTTP APIs"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+files = [
+    {file = "sphinxcontrib-httpdomain-1.8.1.tar.gz", hash = "sha256:6c2dfe6ca282d75f66df333869bb0ce7331c01b475db6809ff9d107b7cdfe04b"},
+    {file = "sphinxcontrib_httpdomain-1.8.1-py2.py3-none-any.whl", hash = "sha256:21eefe1270e4d9de8d717cc89ee92cc4871b8736774393bafc5e38a6bb77b1d5"},
+]
+
+[package.dependencies]
+six = "*"
+Sphinx = ">=1.6"
 
 [[package]]
 name = "sphinxcontrib-jquery"
@@ -1178,4 +1174,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "912941372f3db9c6461bf5607431d2c9e5bff6a0e28facc6e9b875cfe04a4621"
+content-hash = "e63111d2f53c664a753ff79a764c14cb0130fec3230c08e6b11fe182166dcfe7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,14 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 myst-parser = "^1.0.0"
 sphinx = "^5"
-sphinx-autobuild = "2020.9.1"
-sphinx-issues = "1.2.0"
-sphinx-rtd-theme = "1.2.0"
+sphinx-rtd-theme = "^1.2.0"
+sphinxcontrib-httpdomain = "^1.8.1"
+
+[tool.poetry.group.docs-dev]
+optional = true
+
+[tool.poetry.group.docs-dev.dependencies]
+sphinx-autobuild = "^2020.9.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Since we first published the docs, RTD now uses a config file rather
than relying on manual configuration via the website admin interface.
