### PR TITLE
fix: Specify field type for ID columns

### DIFF
--- a/rest_email_auth/apps.py
+++ b/rest_email_auth/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class RestEmailAuthConfig(AppConfig):
+    name = "rest_email_auth"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Specify the default value for the automatically created ID field as it was when the project was created.

Fixes #135
