### PR TITLE
fix: Workflow for publishing versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
Allow the test workflow to be run from the publish workflow.
