### PR TITLE
fix: Publish workflow

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_call:
 
 jobs:
   lint:


### PR DESCRIPTION
Same fix as last time, but for the other dependent workflow.
